### PR TITLE
Sanitize file names.

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -6,7 +6,6 @@ function download(dataObj,callback) {
   var path = require('path');
   var ProgressBar = require('progress');
   var mkdirp = require('mkdirp');
-  var slugify = require('slugify');
   var yargs = require('yargs');
   var argv = yargs
       .usage( "Usage: udl <course_url> [-u \"username\"] [-p \"password\"]" )
@@ -20,12 +19,13 @@ function download(dataObj,callback) {
       .epilog( "By Riaz Ali Laskar" )
       .argv;
   var files = require('./files');
+  var sanitize = require('sanitize-filename');
 
 
   var bar;
   var fileUrl = dataObj.data_url,
       base_path = argv.output ? files.getCurrentDirectoryBase() + path.sep + argv.output : files.getCurrentDirectoryBase(),
-      apiPath = base_path + path.sep + slugify(dataObj.chapter) + path.sep + slugify(dataObj.title)+'.mp4';
+      apiPath = base_path + path.sep + sanitize(dataObj.chapter) + path.sep + sanitize(dataObj.title)+'.mp4';
 
       console.log();
       console.log('Chapter : '+dataObj.chapter);
@@ -40,7 +40,7 @@ function download(dataObj,callback) {
       else
       {
 
-      mkdirp(base_path+path.sep+dataObj.chapter, function (err) {
+      mkdirp(base_path+path.sep+sanitize(dataObj.chapter), function (err) {
           if (err){
              callback(err);
              return;


### PR DESCRIPTION
Use sanitize instead of slugify. Slugify caused an issue where when the title contained ':' it would replace with ':-'.

Also the file name check wasn't added when looking for the folder, so threw an error 'folder not found'.