### PR TITLE
Bugfix for Issue 14 - Unknown resolution

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -16,7 +16,7 @@ var argv = yargs
     .command( "course_url", "URL of the udemy coures to download", { alias: "url" } )
     .option( "u", { alias: "username", demand: false, describe: "Username in udemy", type: "string" } )
     .option( "p", { alias: "password", demand: false, describe: "Password of yor account", type: "string" } )
-    .option( "r", { alias: "resolution", demand: false, describe: "Download video resolution, default resolution is 360, for other video resolutions please refer to the website.", type: "number" } )
+    .option( "r", { alias: "resolution", demand: false, describe: "Maximum download video resolution, default resolution is 360, for other video resolutions please refer to the website.", type: "string" } )
     .option( "o", { alias: "output", demand: false, describe: "Output directory where the videos will be saved, default is current directory", type: "string" } )
     .help( "?" )
     .alias( "?", "help" )
@@ -162,7 +162,11 @@ let check_course_status = function(course_id,cb){
 
   let set_video_resolution = function (element,callback) {
 
-      if(argv.resolution) return;
+      if(argv.resolution) 
+	{
+	callback(null);
+	return;
+	}
 
       var resolution_choices = [];
       let course_id = element.course_id;
@@ -220,7 +224,7 @@ let check_course_status = function(course_id,cb){
                   {
                       type: 'list',
                       name: 'resolution',
-                      message: 'Select the video resolution to download:',
+                      message: 'Select the maximum video resolution to download:',
                       choices:resolution_choices,
                       default: 0
                   }
@@ -229,20 +233,20 @@ let check_course_status = function(course_id,cb){
 
               inquirer.prompt(questions).then(function(reso) {
 
-                  var url = reso.resolution ? list_videos[reso.resolution] : list_videos[360];
+                  // var url = list_videos[1080]
                   // console.log('selection',reso);
                   // console.log('choices',resolution_choices);
                   // console.log('video_list',list_videos);
                   // console.log('url',url);
-                  if(!url)
-                  {
-                      console.log("Unknown video resolution");
-                      process.exit(0);
-                  }
+                  //if(!url)
+                  //{
+                      //console.log("Unknown video resolution");
+                      //process.exit(0);
+                  //}
 
                   argv.resolution = reso.resolution;
 
-                      callback(null);
+                  callback(null);
 
               });
 
@@ -314,10 +318,22 @@ let check_course_status = function(course_id,cb){
 
 
                 var url = argv.resolution ? list_videos[argv.resolution] : list_videos[360];
-               if(!url)
-               {
-                   console.log("Unknown video resolution");
-                   process.exit(0);
+		var r = argv.resolution ? argv.resolution : 360;
+               
+		while(!url)
+               		{
+			switch(r) {
+				case 'Auto': var r = '1080'; break;
+				case '1080': var r = '720'; break;
+				case '720': var r = '480'; break;
+				case '480': var r = '360'; break;
+				default: console.log("At least 1 video is missing valid resolution."); 
+					 process.exit(0);
+					};
+
+			var url = list_videos[r];
+			
+		//console.log('lower res ', r, ' - ', url);
                }
 
                element.data_url  = unescape(url);


### PR DESCRIPTION
Hello,

Going to preface the message with a note that I'm not an engineer and this would be the first time ever using git so I'm not 100% certain I got it all right. If I did the steps correctly I should have committed a bugfix to a new branch that resolved the bug reported as Issue 14 for udemy-dl. The problem I (and likely other users) were running into was that there were select chapters for a given lesson that were not available in the same resolution as the rest of the course. 

I resolved this by changing the if(!url) check into a while loop failing back to progressively lower resolutions until a valid url was found. This allowed the majority of the course to be downloaded in my preferred resolution and each individual course unavailable in that resolution to continue through at the next available. 

The resolution printed to the console during download still appears to be displayed as my max preference instead of what is used for that individual download, but I was unable to see where to make that edit. 

-Jonathan